### PR TITLE
Provided UseCases at ViewModelScope instead of Singleton

### DIFF
--- a/app/src/main/java/com/hieuwu/groceriesstore/di/UseCaseModule.kt
+++ b/app/src/main/java/com/hieuwu/groceriesstore/di/UseCaseModule.kt
@@ -19,42 +19,42 @@ import com.hieuwu.groceriesstore.domain.usecases.UserSettingsUseCaseImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.components.SingletonComponent
-import javax.inject.Singleton
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
 
-@InstallIn(SingletonComponent::class)
+@InstallIn(ViewModelComponent::class)
 @Module
 abstract class UseCaseModule {
 
-    @Singleton
+    @ViewModelScoped
     @Binds
     abstract fun bindGetProductListUseCase(impl: GetProductListUseCaseImpl): GetProductListUseCase
 
-    @Singleton
+    @ViewModelScoped
     @Binds
     abstract fun bindGetProductDetailUseCase(impl: GetProductDetailUseCaseImpl): GetProductDetailUseCase
 
-    @Singleton
+    @ViewModelScoped
     @Binds
     abstract fun bindAuthenticateUserUseCase(impl: AuthenticateUserUseCaseImpl): AuthenticateUserUseCase
 
-    @Singleton
+    @ViewModelScoped
     @Binds
     abstract fun bindUpdateCartItemUseCase(impl: UpdateCartItemUseCaseImpl): UpdateCartItemUseCase
 
-    @Singleton
+    @ViewModelScoped
     @Binds
     abstract fun bindCreateOrderUseCase(impl: CreateOrderUseCaseImpl): CreateOrderUseCase
 
-    @Singleton
+    @ViewModelScoped
     @Binds
     abstract fun bindExploreProductUseCase(impl: ExploreProductProductUseCaseImpl): ExploreProductUseCase
 
-    @Singleton
+    @ViewModelScoped
     @Binds
     abstract fun bindRefreshAppDataUseCase(impl: RefreshAppDataUseCaseImpl): RefreshAppDataUseCase
 
-    @Singleton
+    @ViewModelScoped
     @Binds
     abstract fun bindUserSettingsUseCase(impl: UserSettingsUseCaseImpl): UserSettingsUseCase
 }


### PR DESCRIPTION
Fixes #116 

Earlier all the `UseCases` were provided as singleton to each and every `ViewModel`. Means a **_single instance_** of a particular `UseCase` was shared across various `ViewModels`. In this way, even if any `UseCases` is not required by a `ViewModel`, it was still there in _application level scope_.
Now, all the `UseCases` are scoped by `@ViewModelScope`. Means it will be provided to a `ViewModel` only when it is required. Also If two (or more) `ViewModels` are using same type of `UseCases` then the instance of use-case for each of them would be different. (Read more in the articles mentioned below, especially the last two).
Articles referred:
1. [Dependency Injection with Hilt](https://developer.android.com/training/dependency-injection/hilt-android#component-lifetimes)
2. [Using Hilt’s ViewModelComponent](https://medium.com/androiddevelopers/using-hilts-viewmodelcomponent-53b46515c4f4)
3. [Hilt View Models from dagger.dev](https://dagger.dev/hilt/view-model)