### PR TITLE
Use Gradle version catalog for dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,10 +1,14 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
+plugins {
+    alias libs.plugins.kotlin.android
+    alias libs.plugins.kotlin.kapt
+    alias libs.plugins.android.application
+    alias libs.plugins.hilt.android
+    alias libs.plugins.gms
+    alias libs.plugins.spotless
+    alias libs.plugins.navigation.safeargs
+}
+
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-kapt'
-apply plugin: 'dagger.hilt.android.plugin'
-apply plugin: 'com.google.gms.google-services'
-apply plugin: 'androidx.navigation.safeargs'
 
 android {
     compileSdkVersion 31
@@ -41,82 +45,41 @@ android {
     }
 }
 
-
 dependencies {
-    implementation "androidx.appcompat:appcompat:$appCompatVersion"
-
-    implementation 'com.google.android.material:material:1.6.1'
-
-    //Constraint and Coordinator layout
-    implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
-    implementation "androidx.coordinatorlayout:coordinatorlayout:$coordinatorLayoutVersion"
-    implementation "androidx.legacy:legacy-support-v4:$legacySupportVersion"
-    implementation "io.reactivex.rxjava3:rxjava:$rxJavaVersion"
-
-    //Work Manager
-    implementation "androidx.work:work-runtime-ktx:$workVersion"
-    implementation("androidx.core:core-ktx:$coreVersion")
-
-    // Room
-    implementation "androidx.room:room-runtime:$roomVersion"
-    implementation 'com.google.firebase:firebase-messaging:23.0.6'
-    implementation 'com.android.car.ui:car-ui-lib:2.0.0'
-    kapt "androidx.room:room-compiler:$roomVersion"
-
-    //Navigation component
-    implementation "androidx.navigation:navigation-fragment-ktx:$navigationVersion"
-    implementation "androidx.navigation:navigation-ui-ktx:$navigationVersion"
-
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation libs.bundles.androidx
+    implementation libs.bundles.android.ui
 
-    //Hilt
-    implementation("com.google.dagger:hilt-android:$hiltVersion")
-    kapt("com.google.dagger:hilt-android-compiler:$hiltVersion")
+    implementation libs.kotlin.stdlib
 
-    //Junit for testing
-    testImplementation "junit:junit:$jUnitVersion"
-    androidTestImplementation("androidx.test:runner:$testRunnerVersion")
-    androidTestImplementation "androidx.arch.core:core-testing:$coreTestingVersion"
+    implementation libs.legacy.support.v4
+    implementation libs.rxjava
 
-    //Gson for json parser
-    implementation "com.google.code.gson:gson:$gsonVersion"
+    implementation libs.timber
 
-    //Timber for log
-    implementation "com.jakewharton.timber:timber:$timverVersion"
+    implementation libs.bundles.room
+    kapt libs.room.compiler
 
-    //Livedata
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
-    implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion"
+    implementation libs.hilt
+    kapt libs.hilt.compiler
 
-    //Room
-    implementation "androidx.room:room-ktx:$roomVersion"
-    kapt "androidx.room:room-compiler:$roomVersion"
-    implementation "com.github.bumptech.glide:glide:$glideVersion"
+    implementation libs.glide
+    annotationProcessor libs.glide.compiler
+    implementation libs.lottie
 
-    //Glide for image loading
-    annotationProcessor "com.github.bumptech.glide:compiler:$glideVersion"
+    implementation libs.bundles.retrofit
+    implementation libs.gson
+    implementation libs.moshi
+    implementation libs.kotlin.coroutines.play.services
 
-    //Moshi for json parser
-    implementation("com.squareup.moshi:moshi-kotlin:$moshiVersion")
-    implementation "com.squareup.retrofit2:converter-moshi:$moshiConverterVersion"
+    implementation platform(libs.firebase.bom)
+    implementation libs.bundles.firebase
 
-    //Firebase
-    implementation platform("com.google.firebase:firebase-bom:$firebaseBomVersion")
-    implementation 'com.google.firebase:firebase-auth-ktx'
-    implementation 'com.google.firebase:firebase-database-ktx'
-    implementation 'com.google.firebase:firebase-analytics-ktx'
-    implementation "com.google.firebase:firebase-firestore-ktx:${fireStoreVersion}"
+    implementation libs.caruilib
 
-
-    //Retrofit
-    implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
-    implementation "com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:$kitlinCoroutineAdapter"
-
-    implementation "com.google.android.material:material:$materialVersion"
-    implementation("androidx.cardview:cardview:$cardViewVersion")
-    implementation "com.airbnb.android:lottie:$lottieVersion"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.6.4'
+    testImplementation libs.junit
+    androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.androidx.test.arch.core
 }
 
 task wrapper(type: Wrapper){

--- a/build.gradle
+++ b/build.gradle
@@ -1,57 +1,18 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext {
-        kotlinVersion = "1.6.21"
-        hiltVersion = '2.42'
-        roomVersion = "2.3.0"
-        navigationVersion = "2.4.2"
-        lifecycleVersion = "2.5.0"
-        appCompatVersion = "1.4.2"
-        constraintLayoutVersion = "2.1.4"
-        fireStoreVersion = "24.2.2"
-        coordinatorLayoutVersion = "1.2.0"
-        legacySupportVersion = "1.0.0"
-        gsonVersion = "2.9.0"
-        timverVersion = "5.0.1"
-        glideVersion = "4.13.2"
-        moshiVersion = "1.12.0"
-        moshiConverterVersion = "2.9.0"
-        firebaseBomVersion = "30.3.2"
-        retrofitVersion = "2.9.0"
-        kitlinCoroutineAdapter = "0.9.2"
-        materialVersion = "1.6.1"
-        jUnitVersion = "4.13.2"
-        testRunnerVersion = "1.4.0"
-        coreTestingVersion = "2.1.0"
-        cardViewVersion = "1.0.0"
-        googleServicesVersion = "4.3.13"
-        buildGradleVersion = "7.2.1"
-        rxJavaVersion = "3.1.5"
-        lottieVersion = "5.2.0"
-        workVersion = "2.7.1"
-        coreVersion = "1.8.0"
-    }
-
     repositories {
         google()
-        jcenter()
     }
-    dependencies {
-        classpath "com.android.tools.build:gradle:$buildGradleVersion"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath "com.google.dagger:hilt-android-gradle-plugin:$hiltVersion"
-        classpath "com.google.gms:google-services:$googleServicesVersion"
-        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:$navigationVersion")
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:6.8.0"
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
+}
+
+plugins {
+    alias libs.plugins.spotless apply false
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,104 @@
+[versions]
+appCompatVersion = "1.4.2"
+buildGradleVersion = "7.2.1"
+cardViewVersion = "1.0.0"
+carUiLibVersion = "2.0.0"
+constraintLayoutVersion = "2.1.4"
+coordinatorLayoutVersion = "1.2.0"
+coreTestingVersion = "2.1.0"
+coreVersion = "1.8.0"
+firebaseBomVersion = "30.3.2"
+fireStoreVersion = "24.2.2"
+firebaseVersion = "23.0.6"
+glideVersion = "4.13.2"
+googleServicesVersion = "4.3.13"
+gsonVersion = "2.9.0"
+hiltVersion = '2.42'
+jUnitVersion = "4.13.2"
+kotlinVersion = "1.6.21"
+kotlinCoroutineAdapter = "0.9.2"
+kotlinCoroutinePlayServicesVersion = "1.6.4"
+legacySupportVersion = "1.0.0"
+lifecycleVersion = "2.5.0"
+lottieVersion = "5.2.0"
+materialVersion = "1.6.1"
+moshiConverterVersion = "2.9.0"
+moshiVersion = "1.12.0"
+navigationVersion = "2.4.2"
+retrofitVersion = "2.9.0"
+roomVersion = "2.3.0"
+rxJavaVersion = "3.1.5"
+spotlessVersion = "6.8.0"
+testRunnerVersion = "1.4.0"
+timberVersion = "5.0.1"
+workVersion = "2.7.1"
+
+[libraries]
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appCompatVersion" }
+androidx-core = { module = "androidx.core:core-ktx", version.ref = "coreVersion" }
+androidx-lifecycle-livedata = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycleVersion" }
+androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleVersion" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "testRunnerVersion" }
+androidx-test-arch-core = { module = "androidx.arch.core:core-testing", version.ref = "coreTestingVersion" }
+androidx-work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref = "workVersion" }
+cardview = { module = "androidx.cardview:cardview", version.ref = "cardViewVersion" }
+caruilib = { module = "com.android.car.ui:car-ui-lib", version.ref = "carUiLibVersion" }
+constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintLayoutVersion" }
+coordinatorlayout = { module = "androidx.coordinatorlayout:coordinatorlayout", version.ref = "coordinatorLayoutVersion" }
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBomVersion" }
+firebase-auth = { module = "com.google.firebase:firebase-auth-ktx" }
+firebase-database = { module = "com.google.firebase:firebase-database-ktx" }
+firebase-analytics = { module = "com.google.firebase:firebase-analytics-ktx" }
+firebase-firestore = { module = "com.google.firebase:firebase-firestore-ktx", version.ref = "fireStoreVersion" }
+firebase-messaging = { module = "com.google.firebase:firebase-messaging", version.ref = "firebaseVersion" }
+glide = { module = "com.github.bumptech.glide:glide", version.ref = "glideVersion" }
+glide-compiler = { module = "com.github.bumptech.glide:compiler", version.ref = "glideVersion" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gsonVersion" }
+hilt = { module = "com.google.dagger:hilt-android", version.ref = "hiltVersion" }
+hilt-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hiltVersion" }
+junit = { module = "junit:junit", version.ref = "jUnitVersion" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlinVersion" }
+kotlin-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinCoroutinePlayServicesVersion" }
+legacy-support-v4 = { module = "androidx.legacy:legacy-support-v4", version.ref = "legacySupportVersion" }
+lottie = { module = "com.airbnb.android:lottie", version.ref = "lottieVersion" }
+material-components = { module = "com.google.android.material:material", version.ref = "materialVersion" }
+moshi = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshiVersion" }
+navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigationVersion" }
+navigation-ui = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigationVersion" }
+retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofitVersion" }
+retrofit-converter-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "moshiConverterVersion" }
+retrofit-coroutines-adapter = { module = "com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter", version.ref = "kotlinCoroutineAdapter" }
+rxjava = { module = "io.reactivex.rxjava3:rxjava", version.ref = "rxJavaVersion" }
+room = { module = "androidx.room:room-ktx", version.ref = "roomVersion" }
+room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomVersion" }
+room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomVersion" }
+timber = { module = "com.jakewharton.timber:timber", version.ref = "timberVersion" }
+
+[bundles]
+androidx = [
+    "androidx-core",
+    "androidx-lifecycle-livedata",
+    "androidx-lifecycle-runtime",
+    "androidx-work-runtime",
+]
+android-ui = [
+    "androidx-appcompat",
+    "cardview",
+    "constraintlayout",
+    "coordinatorlayout",
+    "material-components",
+    "navigation-fragment",
+    "navigation-ui",
+]
+firebase = ["firebase-auth", "firebase-database", "firebase-analytics", "firebase-firestore", "firebase-messaging"]
+retrofit = ["retrofit", "retrofit-converter-moshi", "retrofit-coroutines-adapter"]
+room = ["room", "room-runtime"]
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "buildGradleVersion" }
+gms = { id = "com.google.gms.google-services", version.ref = "googleServicesVersion" }
+hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hiltVersion" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinVersion" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlinVersion" }
+navigation-safeargs = { id = "androidx.navigation.safeargs", version.ref = "navigationVersion"}
+spotless = { id = "com.diffplug.spotless", version.ref = "spotlessVersion" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,10 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+
 include ':app'
 rootProject.name = "Groceries Store"


### PR DESCRIPTION
Use the Gradle version catalog feature for dependencies, by moving libraries, versions and plugins to a TOML file. Dependencies with multiple artifacts, such as Firebase, have been bundled. This allows for a more readable dependency block in the build.gradle file.

Also use the plugins {...} block in favor of the legacy "apply plugin". This allows us to skip the classpath declaration in the root build.gradle file.

Fixes #141.